### PR TITLE
[CI] Trigger browser tests on tag release

### DIFF
--- a/.github/workflows/browser-tests-v3.yaml
+++ b/.github/workflows/browser-tests-v3.yaml
@@ -1,0 +1,53 @@
+name: Browser tests
+
+on:
+    push:
+        tags:
+            - 'v3*'
+
+jobs:
+    regression-oss-setup1:
+        name: "PHP 7.4/PostgreSQL/Varnish/Redis"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "oss"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=oss"
+            test-setup-phase-1: "--profile=regression --suite=setup-oss --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            multirepository: true
+            job-count: 2
+            timeout: 60
+        secrets:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    regression-oss-setup2:
+        name: "PHP 7.3/MySQL"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "oss"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=oss"
+            test-setup-phase-1: "--profile=regression --suite=setup-oss --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            multirepository: true
+            php-image: "ezsystems/php:7.3-v2-node14"
+            job-count: 2
+            timeout: 60
+        secrets:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    regression-oss-setup3:
+        name: "PHP 8.1/MySQL"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "oss"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=oss"
+            test-setup-phase-1: "--profile=regression --suite=setup-oss --mode=standard"
+            php-image: "ezsystems/php:8.1-v2-node16"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            job-count: 2
+            timeout: 60
+        secrets:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/browser-tests-v4.yaml
+++ b/.github/workflows/browser-tests-v4.yaml
@@ -1,0 +1,41 @@
+name: Browser tests
+
+on:
+    push:
+        tags:
+            - 'v4*'
+
+jobs:
+    regression-oss-setup1:
+        name: "PHP 7.4/Node 14/PostgreSQL/Varnish/Redis"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "oss"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=oss"
+            test-setup-phase-1: "--profile=regression --suite=setup-oss --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            multirepository: true
+            php-image: "ezsystems/php:7.4-v2-node14"
+            job-count: 2
+            timeout: 60
+        secrets:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    regression-oss-setup2:
+        name: "PHP 8.1/Node 16/MySQL/Compatibility layer"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "oss"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=oss"
+            test-setup-phase-1: "--profile=regression --suite=setup-oss --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            multirepository: true
+            use-compatibility-layer: true
+            job-count: 2
+            timeout: 60
+            php-image: "ezsystems/php:8.1-v2-node16"
+        secrets:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-2317

Requires:
https://github.com/ibexa/gh-workflows/pull/23
https://github.com/ibexa/ci-scripts/pull/53

Contains TMP commit: https://github.com/ibexa/oss-skeleton/pull/1/commits/3a742dc4fdbb5143f3a14355bdecfb112f93c712 that must be removed

The workflows are copied from:
https://github.com/ibexa/oss/blob/master/.github/workflows/browser-tests.yml
https://github.com/ibexa/oss/blob/3.3/.github/workflows/browser-tests.yml

The only new thing is the part with:
```
on:
    push:
        tags:
            - 'v3*'
```
which decides which workflow should run when a tag is pushed
